### PR TITLE
feat: run database migrations with GitHub Actions

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -1,0 +1,16 @@
+name: Migrations
+
+ on:
+   workflow_dispatch:
+
+ jobs:
+   build:
+     runs-on: macos-latest
+     env:
+       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+     steps:
+       - name: Checkout project files
+         uses: actions/checkout@v2
+
+       - name: Run migrationos
+         run: ./bin/sqlx-cli migrate run


### PR DESCRIPTION
As we migrate to SQLx on #9 we can take advantage of the SQLx CLI to run migrations
from GitHub Actions. A copy of the binary is included under `bin`. A workflow dispatch
action is provided which runs `sql migration run` using our `DATABASE_URL` environment
variable.
