### PR TITLE
fix(user): graphql enums

### DIFF
--- a/src/modules/user/entity.rs
+++ b/src/modules/user/entity.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 #[derive(Copy, Clone, Debug, Deserialize, Enum, PartialEq, Eq, Serialize, sqlx::Type)]
+#[sqlx(rename_all = "lowercase")]
 pub enum Gender {
     Female,
     Male,
@@ -21,6 +22,7 @@ impl ToString for Gender {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, Enum, PartialEq, Eq, Serialize, sqlx::Type)]
+#[sqlx(rename_all = "lowercase")]
 pub enum Pronoun {
     He,
     She,


### PR DESCRIPTION
When I tried to create a user, the graphql playground gave me the following error:

![Screenshot from 2022-05-04 22:58:03](https://user-images.githubusercontent.com/49698182/166858158-9d0512c1-168d-4ab0-8451-3f755bfec8a3.png)

In the code, the `ToString` is implemented for the enums, so that they are read/fetched in lowercase format, graphql threw the error because it could not decode the enum.

Reading the doc, I found that using `#[sqlx(rename_all="lowercase"]` converts the enum to lowercase, which resolves the error:

![Screenshot from 2022-05-04 23:00:49](https://user-images.githubusercontent.com/49698182/166858842-e47e52db-06f0-440a-bcbf-c560ad980972.png)

You can read more about enums [here](https://docs.rs/sqlx/latest/sqlx/postgres/types/index.html#enumerations)

