### PR TITLE
feat: impl `DataLoader<UserLoader>` for `posts` and `feed`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
 
 [[package]]
 name = "async-graphql"
-version = "3.0.30"
+version = "3.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914de0823f31af0731728df2f4cb2c231f40c087d30f8431e91cd035ba020466"
+checksum = "2106123e9c79a8d649bf0f7e9f58462a90ce2ca71ad9a0b69b4f2b67382c376f"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -74,9 +74,12 @@ dependencies = [
  "chrono",
  "fast_chemail",
  "fnv",
+ "futures-channel",
+ "futures-timer",
  "futures-util",
  "http",
  "indexmap",
+ "lru",
  "mime",
  "multer",
  "num-traits",
@@ -93,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "3.0.30"
+version = "3.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac9005f90bc0b3f2dcb1cad62161a26a2e0eb66361c21575633ff3b2103cc5b"
+checksum = "1a6ec150ac445a660169a3ad5075b953a7351ec75fe28095e639f6282aac9fdb"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -109,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "3.0.30"
+version = "3.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50095c38b0f0a3fcbf1bc0bbadaee9497fac0c08b0a48918b30b489bc3252928"
+checksum = "0302764f05e0e50fd3b381646d4a0ed07d4ce5c9fc1eaf79bbd7745bd4893adb"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -122,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-rocket"
-version = "3.0.30"
+version = "3.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6108a7101c200d5c091de3f6c52106a8609ec8f35c16e5e5d4bdb7b90bcbbfd"
+checksum = "53c227d32ebeef690397fbd2a01397738b33b1a55b7c2dd6159cdde01318b769"
 dependencies = [
  "async-graphql",
  "rocket",
@@ -135,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "3.0.30"
+version = "3.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce0d8a2d439e8dff50f23b890a0fc9d056e80ab5cfe26ee937c2d0f04671be6"
+checksum = "ba2e19876bcd2068f597fd0182f4ba602ce3c89cb04c4b8810d7c36f44724e92"
 dependencies = [
  "bytes",
  "indexmap",
@@ -685,6 +688,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1024,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8015d95cb7b2ddd3c0d32ca38283ceb1eea09b4713ee380bceb942d85a244228"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1131,7 @@ dependencies = [
  "base64",
  "chrono",
  "dotenv",
+ "itertools",
  "jsonwebtoken",
  "rand",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-graphql = { version = "3.0.15", features = ["chrono", "uuid"] }
-async-graphql-rocket = "3.0.15"
+async-graphql = { version = "3.0.38", features = ["chrono", "dataloader", "uuid"] }
+async-graphql-rocket = "3.0.38"
 base64 = "0.13.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 dotenv = "0.15.0"
-sqlx = { version = "0.5", features = [ "chrono", "postgres", "runtime-tokio-rustls", "uuid" ] }
+itertools = "0.10.3"
 jsonwebtoken = "8.0.1"
 rand = "0.8.5"
 regex = "1.5.5"
@@ -19,5 +19,6 @@ rocket = { version = "0.5.0-rc.1", features = ["json"] }
 rust-argon2 = "1.0.0"
 serde = "1.0.130"
 serde_json = "1.0.68"
+sqlx = { version = "0.5", features = [ "chrono", "postgres", "runtime-tokio-rustls", "uuid" ] }
 thiserror = "1.0.30"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ pub enum ErrorCode {
     Unhandled,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct Error {
     pub field: Option<String>,
     pub message: Option<String>,

--- a/src/graphql/loaders/mod.rs
+++ b/src/graphql/loaders/mod.rs
@@ -1,0 +1,3 @@
+mod user;
+
+pub use user::UserLoader;

--- a/src/graphql/loaders/user.rs
+++ b/src/graphql/loaders/user.rs
@@ -1,0 +1,45 @@
+use async_graphql::dataloader::Loader;
+use async_graphql::*;
+use itertools::Itertools;
+use std::collections::HashMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::database::Database;
+use crate::error::Error;
+use crate::modules::user::{User, UsersTableRow};
+
+pub struct UserLoader {
+    database: Arc<Database>,
+}
+
+impl UserLoader {
+    pub fn new(database: Arc<Database>) -> Self {
+        Self { database }
+    }
+}
+
+#[async_trait::async_trait]
+impl Loader<Uuid> for UserLoader {
+    type Value = User;
+    type Error = Error;
+
+    async fn load(&self, keys: &[Uuid]) -> Result<HashMap<Uuid, Self::Value>, Self::Error> {
+        let query = format!(
+            "SELECT * FROM users WHERE id IN ({})",
+            keys.iter()
+                .map(|uuid| { format!("'{}'::uuid", uuid) })
+                .join(",")
+        );
+        let result: Vec<UsersTableRow> = sqlx::query_as(&query)
+            .fetch_all(&self.database.conn_pool)
+            .await?;
+        let mut res: HashMap<Uuid, User> = HashMap::new();
+
+        result.into_iter().for_each(|u: UsersTableRow| {
+            res.insert(u.id, User::from(u));
+        });
+
+        Ok(res)
+    }
+}

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -1,3 +1,4 @@
+pub mod loaders;
 pub mod relay;
 
 use async_graphql::{EmptySubscription, MergedObject};

--- a/src/modules/post/entity.rs
+++ b/src/modules/post/entity.rs
@@ -1,4 +1,4 @@
-use async_graphql::{Enum, SimpleObject};
+use async_graphql::Enum;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -19,7 +19,7 @@ impl ToString for Scope {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, SimpleObject)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Post {
     pub id: Uuid,
     pub content: String,

--- a/src/modules/post/graphql/mutation/post_create.rs
+++ b/src/modules/post/graphql/mutation/post_create.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::error::Result;
-use crate::modules::post::graphql::PostError;
-use crate::modules::post::{Post, Scope};
+use crate::modules::post::graphql::{Post, PostError};
+use crate::modules::post::Scope;
 use crate::routes::AuthToken;
 use crate::services::Services;
 
@@ -28,9 +28,16 @@ impl PostCreate {
         let token = auth.token()?;
         let user = services.auth.whoami(token).await?;
 
-        match services.post.create(user, input).await {
+        match services.post.create(user.clone(), input).await {
             Ok(post) => Ok(PostCreate {
-                post: Some(post),
+                post: Some(Post {
+                    id: post.id,
+                    content: post.content,
+                    user,
+                    scope: post.scope,
+                    created_at: post.created_at,
+                    updated_at: post.updated_at,
+                }),
                 error: None,
             }),
             Err(err) => {

--- a/src/modules/post/graphql/query/mod.rs
+++ b/src/modules/post/graphql/query/mod.rs
@@ -1,9 +1,11 @@
+pub mod feed;
 pub mod posts;
 
 use async_graphql::{Context, Object};
 
 use crate::error::Result;
 
+use self::feed::Feed;
 use self::posts::Posts;
 
 #[derive(Default)]
@@ -11,6 +13,18 @@ pub struct PostQuery;
 
 #[Object]
 impl PostQuery {
+    #[graphql(name = "feed")]
+    async fn feed(
+        &self,
+        ctx: &Context<'_>,
+        after: Option<String>,
+        before: Option<String>,
+        first: Option<i32>,
+        last: Option<i32>,
+    ) -> Result<Feed> {
+        Feed::exec(ctx, after, before, first, last).await
+    }
+
     #[graphql(name = "posts")]
     async fn posts(
         &self,

--- a/src/modules/post/graphql/types.rs
+++ b/src/modules/post/graphql/types.rs
@@ -1,7 +1,21 @@
 use async_graphql::{Enum, SimpleObject};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::error::{Error, ErrorCode};
+use crate::modules::post::Scope;
+use crate::modules::user::User;
+
+#[derive(Clone, Debug, Deserialize, Serialize, SimpleObject)]
+pub struct Post {
+    pub id: Uuid,
+    pub content: String,
+    pub user: User,
+    pub scope: Scope,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize, SimpleObject)]
 pub struct PostError {
@@ -13,16 +27,6 @@ pub struct PostError {
 #[derive(Clone, Copy, Debug, Deserialize, Enum, Eq, PartialEq, Serialize)]
 pub enum PostErrorCode {
     Unauthorized,
-}
-
-impl PostError {
-    pub fn unathorized() -> Self {
-        PostError {
-            field: None,
-            message: Some(String::from("Token is either missing or invalid.")),
-            code: PostErrorCode::Unauthorized,
-        }
-    }
 }
 
 impl TryFrom<Error> for PostError {

--- a/src/modules/post/repository.rs
+++ b/src/modules/post/repository.rs
@@ -98,4 +98,24 @@ impl PostRepository {
             updated_at: result.updated_at,
         })
     }
+
+    pub async fn find_public_posts(&self) -> Result<Vec<Post>> {
+        let result: Vec<PostsTableRow> =
+            sqlx::query_as("SELECT * FROM posts WHERE scope = 'public' LIMIT 20")
+                .fetch_all(&self.database.conn_pool)
+                .await?;
+        let posts = result
+            .into_iter()
+            .map(|row| Post {
+                id: row.id,
+                user_id: row.user_id,
+                content: row.content,
+                scope: row.scope,
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+            })
+            .collect::<Vec<Post>>();
+
+        Ok(posts)
+    }
 }

--- a/src/modules/post/service.rs
+++ b/src/modules/post/service.rs
@@ -47,4 +47,21 @@ impl PostService {
 
         Ok(posts)
     }
+
+    pub async fn find_public_posts(&self) -> Result<Vec<Post>> {
+        let posts = self.repository.find_public_posts().await?;
+        let posts: Vec<Post> = posts
+            .into_iter()
+            .map(|post| Post {
+                id: post.id,
+                content: post.content,
+                scope: post.scope,
+                user_id: post.user_id,
+                created_at: post.created_at,
+                updated_at: post.updated_at,
+            })
+            .collect();
+
+        Ok(posts)
+    }
 }

--- a/src/modules/user/graphql/types.rs
+++ b/src/modules/user/graphql/types.rs
@@ -10,16 +10,6 @@ pub struct UserError {
     code: UserErrorCode,
 }
 
-impl UserError {
-    pub fn unathorized() -> Self {
-        UserError {
-            field: None,
-            message: Some(String::from("Token is either missing or invalid.")),
-            code: UserErrorCode::Unauthorized,
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, Deserialize, Enum, Eq, PartialEq, Serialize)]
 pub enum UserErrorCode {
     Unauthorized,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -6,7 +6,6 @@ use rocket::{Request, State};
 
 use crate::error::{Error, Result};
 use crate::graphql::Schema;
-use crate::modules::auth;
 use crate::responders::cors::{Cors, CorsPreflight};
 
 #[derive(Debug)]

--- a/src/services.rs
+++ b/src/services.rs
@@ -13,8 +13,7 @@ pub struct Services {
 }
 
 impl Services {
-    pub fn new(config: &Config, database: Database) -> Self {
-        let database = Arc::new(database);
+    pub fn new(config: &Config, database: Arc<Database>) -> Self {
         let user_repository = Arc::new(UserRepository::new(Arc::clone(&database)));
         let user_service = Arc::new(UserService::new(Arc::clone(&user_repository)));
         let post_repository = Arc::new(PostRepository::new(Arc::clone(&database)));


### PR DESCRIPTION
Implements [`DataLoader`][1] to load User entities for Posts on an optimized manner and
avoid the N+1 issue. As of today this loader is only used for loading a user's posts and the
application feed.

[1]: https://github.com/graphql/dataloader